### PR TITLE
Environmental variable support for the CLI tool

### DIFF
--- a/bin/prettyjson
+++ b/bin/prettyjson
@@ -2,7 +2,11 @@
 
 var prettyjson = require('../lib/prettyjson');
 var fs=require('fs');
-
+var options = {
+  keysColor: process.env.JSON_PP_KEY_COLOR,
+  dashColor: process.env.JSON_PP_DASH_COLOR,
+  defaultIndent: process.env.JSON_PP_INDENT
+};
 
 var renderInputJson = function(input){
   if (input === '') {
@@ -10,7 +14,7 @@ var renderInputJson = function(input){
   }
   try {
     var inputData = JSON.parse(input);
-    console.log(prettyjson.render(inputData));
+    console.log(prettyjson.render(inputData, options));
   } catch (e) {
     console.log('Error:'.red + ' Not valid JSON!');
   }


### PR DESCRIPTION
I like this module a lot, i would love to see it get incorporated into [jsontool](https://github.com/trentm/json) as an output filter :)

This change is pretty simple, it allows you to specify environmental variables to change the colors for the CLI tool.

```
$ export JSON_PP_DASH_COLOR=black
$ export JSON_PP_KEY_COLOR=cyan
```
