### PR TITLE
Add pretty printing of errors

### DIFF
--- a/lib/prettyjson.js
+++ b/lib/prettyjson.js
@@ -109,26 +109,35 @@ exports.render = function render(data, options, indentation) {
     // Get the size of the longest index to render all the values on the same column
     var maxIndexLength = Utils.getMaxIndexLength(data);
     var key;
+    var isError = data instanceof Error;
 
-    for(var i in data) {
-      if (data.hasOwnProperty(i)) {
-          // Prepend the index at the beginning of the line
-          key = Utils.indent(indentation) + (i + ': ')[options.keysColor];
+    Object.getOwnPropertyNames(data).forEach(function(i) {
+      // Prepend the index at the beginning of the line
+      key = Utils.indent(indentation) + (i + ': ')[options.keysColor];
 
-          // If the value is serializable, render it in the same line
-          if (isSerializable(data[i])) {
-              key += exports.render(data[i], options, maxIndexLength - i.length);
-              output.push(key);
-
-              // If the index is an array or object, render it in next line
-          } else {
-              output.push(key);
-              output.push(
-                  exports.render(data[i], options, indentation + options.defaultIndentation)
-              );
-          }
+      // Skip `undefined`, it's not a valid JSON value.
+      if (data[i] === undefined) {
+        return;
       }
-    }
+
+      // If the value is serializable, render it in the same line
+      if (isSerializable(data[i]) && (!isError || i !== 'stack')) {
+        key += exports.render(data[i], options, maxIndexLength - i.length);
+        output.push(key);
+
+        // If the index is an array or object, render it in next line
+      } else {
+        output.push(key);
+        output.push(
+          exports.render(
+            isError && i === 'stack'
+              ? data[i].split('\n')
+              : data[i],
+            options, indentation + options.defaultIndentation
+          )
+        );
+      }
+    });
   }
   // Return all the lines as a string
   return output.join('\n');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,10 +14,8 @@ exports.getMaxIndexLength = function(input) {
   var maxWidth = 0;
   var key;
 
-  for (key in input) {
-    if (input.hasOwnProperty(key) && key.length > maxWidth) {
-      maxWidth = key.length;
-    }
-  }
+  Object.getOwnPropertyNames(input).forEach(function(key) {
+    maxWidth = Math.max(maxWidth, key.length);
+  });
   return maxWidth;
 };

--- a/test/prettyjson_spec.js
+++ b/test/prettyjson_spec.js
@@ -207,6 +207,20 @@ describe('Printing numbers, booleans and other objects', function() {
 
     output.should.equal('    ' + 'null'.grey);
   });
+
+  it("should print an Error correctly ", function() {
+    Error.stackTraceLimit = 1;
+    var input = new Error('foo');
+    var stack = input.stack.split('\n');
+    var output = prettyjson.render(input, {}, 4);
+
+    output.should.equal([
+      '    ' + 'stack: '.green,
+      '      ' + '- '.green + stack[0],
+      '      ' + '- '.green + stack[1],
+      '    ' + 'message: '.green + '  foo'
+    ].join('\n'));
+  });
 });
 
 describe('prettyjson.renderString() method', function(){


### PR DESCRIPTION
Previously, error was output as an empty key (since iterating over an
error with `for .. in` is an empty loop).

Split stacks into arrays so that they are easily readable.
