### PR TITLE
Render bools, numbers, strings and null at same line while rendering array

### DIFF
--- a/lib/prettyjson.js
+++ b/lib/prettyjson.js
@@ -80,8 +80,9 @@ exports.render = function render(data, options, indentation) {
         // Prepend the dash at the begining of each array's element line
         var line = Utils.indent(indentation) + ('- ')[options.dashColor];
 
-        // If the element of the array is a string, render it in the same line
-        if (typeof element === 'string') {
+        // If the element of the array is a string, bool, number, or null
+        // render it in the same line
+        if (isSerializable(element)) {
           line += exports.render(element, options);
           output.push(line);
 


### PR DESCRIPTION
While rendering array, prettyjson shows unexpected result for any scalar, except strings.

`console.log(prettyjson.render([true, false]));` will produce

```
 - 
    true
 -
    false
```

This patch fixes it and output will be:

```
 - true
 - false
```
