### PR TITLE
Wrong parameter name to disable coloring option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ var data = {
 };
 
 var options = {
-  noColors: true
+  noColor: true
 };
 
 console.log(prettyjson.render(data, options));


### PR DESCRIPTION
It took me a while to understand why I'm still getting colored output, please fix wrong name of parameter noColors in the README.md
