### PR TITLE
indent multiline strings

### DIFF
--- a/lib/prettyjson.js
+++ b/lib/prettyjson.js
@@ -23,7 +23,6 @@ exports.version = require('../package.json').version;
 //       defaultIndentation: 2     // Indentation on nested objects
 //     }
 exports.render = function render(data, options, indentation) {
-
   // Default values
   indentation = indentation || 0;
   options = options || {};
@@ -40,11 +39,22 @@ exports.render = function render(data, options, indentation) {
 
   // Helper function to detect if an object can be directly serializable
   var isSerializable = function(input) {
-    if (typeof input === 'string' || typeof input === 'boolean' ||
+    if (typeof input === 'boolean' ||
         typeof input === 'number' || input === null) {
       return true;
     }
+    if (typeof input === 'string' && input.indexOf('\n') === -1) {
+      return true;
+    }
     return false;
+  };
+
+  var indentLines = function(string, spaces){
+    var lines = string.split('\n');
+    lines = lines.map(function(line){
+      return Utils.indent(spaces) + line;
+    });
+    return lines.join('\n');
   };
 
   var addColorToData = function(input) {
@@ -77,6 +87,12 @@ exports.render = function render(data, options, indentation) {
   // Render a string exactly equal
   if (isSerializable(data)) {
     output.push(Utils.indent(indentation) + addColorToData(data));
+  }
+  else if (typeof data == 'string') {
+    //unserializable string means it's multiline
+    output.push(Utils.indent(indentation) + '"""');
+    output.push(indentLines(data, indentation + options.defaultIndentation));
+    output.push(Utils.indent(indentation) + '"""');
   }
   else if (Array.isArray(data)) {
     // If the array is empty, render the `emptyArrayMsg`

--- a/test/prettyjson_spec.js
+++ b/test/prettyjson_spec.js
@@ -19,6 +19,14 @@ describe('prettyjson general tests', function() {
     output.should.equal('    ' + input);
   });
 
+  it("should output a multiline string with indentation", function() {
+
+    var input = 'multiple\nlines'
+    var output = prettyjson.render(input, {}, 4);
+
+    output.should.equal('    """\n      multiple\n      lines\n    """');
+  });
+
   it("should output an array of strings", function() {
 
     var input = ['first string', 'second string'];


### PR DESCRIPTION
If a value is a multiline string, the indentation of the output can look jagged. This PR forces the indentation to be used within multiline strings. It also adds a wrapper to make it more clear that this is happening.

Before this PR:

``` javascript
var obj = {
  message: "something went wrong:\nit didn't start"
};
console.log(render(ojb), {}, 4);

/*
    message: something went wrong:
it didn't start
*/
```

After this PR:

``` javascript
var obj = {
  message: "something went wrong:\nit didn't start"
};
console.log(render(ojb), {}, 4);

/*
    message: 
      """
        something went wrong:
        it didn't start
      """
*/
```

I'm open to thoughts on the exact formatting. I could really use this feature in general, though.
