### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "https://github.com/rafeca/prettyjson/issues"
   },
   "main": "./lib/prettyjson",
+  "license": "MIT",
   "scripts": {
     "test": "npm run jshint && mocha --reporter spec",
     "testwin": "node ./node_modules/mocha/bin/mocha --reporter spec",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/