### PR TITLE
[Ganesh/Abhishek] - fixed bug in specified color

### DIFF
--- a/lib/prettyjson.js
+++ b/lib/prettyjson.js
@@ -1,10 +1,17 @@
 'use strict';
 
 // ### Module dependencies
-require('colors');
+var colors = require('colors');
 var Utils = require('./utils');
 
 exports.version = require('../package.json').version;
+
+var supportedColors = (function(){
+  var validColors = colors.styles;
+  for(var key in colors.maps)
+    validColors[key] = colors.maps[key];
+  return validColors;
+})();
 
 // ### Render function
 // *Parameters:*
@@ -27,13 +34,13 @@ exports.render = function render(data, options, indentation) {
   indentation = indentation || 0;
   options = options || {};
   options.emptyArrayMsg = options.emptyArrayMsg || '(empty array)';
-  options.keysColor = options.keysColor || 'green';
-  options.dashColor = options.dashColor || 'green';
-  options.numberColor = options.numberColor || 'blue';
+  options.keysColor = supportedColors[options.keysColor] ? options.keysColor : 'green';
+  options.dashColor = supportedColors[options.dashColor] ? options.dashColor : 'green';
+  options.numberColor = supportedColors[options.numberColor] ? options.numberColor : 'blue';
   options.defaultIndentation = options.defaultIndentation || 2;
   options.noColor = !!options.noColor;
 
-  options.stringColor = options.stringColor || null;
+  options.stringColor = supportedColors[options.stringColor] ? options.stringColor : null;
 
   var output = [];
 

--- a/test/prettyjson_spec.js
+++ b/test/prettyjson_spec.js
@@ -346,3 +346,33 @@ describe('prettyjson.renderString() method', function(){
     output.should.equal('test: '.green + 'OK'.red);
   });
 });
+
+describe('Colors Validation', function(){
+  it('should output the string with default scheme if invalid colors are provided', function(){
+    var input = {param1: 'first string', param2: 'second string'};
+    var output = prettyjson.render(input, {keysColor: 'orange', stringColor: 'pink'});
+
+    output.should.equal([
+      'param1: '.green + 'first string',
+      'param2: '.green + 'second string'
+    ].join('\n'));
+  });
+
+  it('should output the number with default scheme if invalid colors are provided', function(){
+    var input = {param1: 17, param2: 22.3};
+    var output = prettyjson.render(input, {numberColor: 'pink'});
+
+    output.should.equal([
+      'param1: '.green + '17'.blue,
+      'param2: '.green + '22.3'.blue
+    ].join('\n'));
+  });
+
+  it('should output the number with default scheme if invalid colors are provided', function(){
+    var input = {param1: ['pretty']};
+    var output = prettyjson.render(input, {dashColor: 'pink'});
+    
+    output.should.equal('param1: '.green +'\n  '+ '- '.green + 'pretty');
+
+  });
+});


### PR DESCRIPTION
What changes have you made?
  Changes made while printing json with user specified colors
  Previously user was able to specify any color(invalid color)
  because of which all the data was printing as undefined

  Added a check before printing data that if the user specified color
is invalid then use the default colors.

Why do we need this change?
  To print the data with valid options and color schemes

Files Modified:

	modified:   lib/prettyjson.js
	modified:   test/prettyjson_spec.js