### PR TITLE
Fix prettyjson.js

### DIFF
--- a/lib/prettyjson.js
+++ b/lib/prettyjson.js
@@ -141,7 +141,10 @@ exports.render = function render(data, options, indentation) {
     var key;
     var isError = data instanceof Error;
 
-    Object.getOwnPropertyNames(data).forEach(function(i) {
+    Object.keys(data).forEach(function(i) {
+      if (!data.propertyIsEnumerable(i)) {
+	return;
+      }
       // Prepend the index at the beginning of the line
       key = (i + ': ');
       if (!options.noColor) {


### PR DESCRIPTION
getOwnPropertyNames function does not respect keys order (instead of keys function)
