### PR TITLE
Add option to avoid aligning values relative to longest index

### DIFF
--- a/bin/prettyjson
+++ b/bin/prettyjson
@@ -11,6 +11,7 @@ var options = {
   stringColor: argv.string || process.env.PRETTYJSON_STRING,
   numberColor: argv.number || process.env.PRETTYJSON_NUMBER,
   noColor: argv['nocolor'] || process.env.PRETTYJSON_NOCOLOR,
+  noAlign: argv['noalign'] || process.env.PRETTYJSON_NOALIGN,
   inlineArrays: argv['inline-arrays'] || process.env.PRETTYJSON_INLINE_ARRAYS
 };
 

--- a/lib/prettyjson.js
+++ b/lib/prettyjson.js
@@ -32,6 +32,7 @@ exports.render = function render(data, options, indentation) {
   options.numberColor = options.numberColor || 'blue';
   options.defaultIndentation = options.defaultIndentation || 2;
   options.noColor = !!options.noColor;
+  options.noAlign = !!options.noAlign;
 
   options.stringColor = options.stringColor || null;
 
@@ -136,8 +137,9 @@ exports.render = function render(data, options, indentation) {
     }
   }
   else if (typeof data === 'object') {
-    // Get the size of the longest index to align all the values
-    var maxIndexLength = Utils.getMaxIndexLength(data);
+    // If values alignment is enabled, get the size of the longest index
+    // to align all the values
+    var maxIndexLength = options.noAlign ? 0 : Utils.getMaxIndexLength(data);
     var key;
     var isError = data instanceof Error;
 
@@ -156,7 +158,8 @@ exports.render = function render(data, options, indentation) {
 
       // If the value is serializable, render it in the same line
       if (isSerializable(data[i]) && (!isError || i !== 'stack')) {
-        key += exports.render(data[i], options, maxIndexLength - i.length);
+        var nextIndentation = options.noAlign ? 0 : maxIndexLength - i.length;
+        key += exports.render(data[i], options, nextIndentation);
         output.push(key);
 
         // If the index is an array or object, render it in next line

--- a/test/prettyjson_spec.js
+++ b/test/prettyjson_spec.js
@@ -87,6 +87,17 @@ describe('prettyjson general tests', function() {
     ].join('\n'));
   });
 
+  it("should allow to disable values aligning with longest index", function() {
+
+    var input = {very_large_param: 'first string', param: 'second string'};
+    var output = prettyjson.render(input, {noAlign: true});
+
+    output.should.equal([
+      'very_large_param: '.green + 'first string',
+      'param: '.green + 'second string'
+    ].join('\n'));
+  });
+
   it("should output a really nested object", function() {
 
     var input = {


### PR DESCRIPTION
Hi, I needed to prettify something without the values being aligned relative to the longest index, so I added a noAlign option (--noalign on the CLI).

I thought maybe you want to merge this back to the project. I can change the option's name to something more descriptive if there are any ideas.

Nice tool!
