### PR TITLE
Escape string in case of conflict chars, and add noEscape option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ $ prettyjson --indent=4 package.json
 
 # Render arrays elements in a single line
 $ prettyjson --inline-arrays=1 package.json
+
+# Escape conflictive strings
+$ prettyjson --escape=1 package.json
 ```
 
 **Deprecation Notice**: The old configuration through environment variables is

--- a/bin/prettyjson
+++ b/bin/prettyjson
@@ -13,6 +13,7 @@ var options = {
   numberColor: argv.number || process.env.PRETTYJSON_NUMBER,
   noColor: argv['nocolor'] || process.env.PRETTYJSON_NOCOLOR,
   noAlign: argv['noalign'] || process.env.PRETTYJSON_NOALIGN,
+  noEscape argv['noescape'] || process.env.PRETTYJSON_NOESCAPE,
   inlineArrays: argv['inline-arrays'] || process.env.PRETTYJSON_INLINE_ARRAYS
 };
 

--- a/bin/prettyjson
+++ b/bin/prettyjson
@@ -13,7 +13,7 @@ var options = {
   numberColor: argv.number || process.env.PRETTYJSON_NUMBER,
   noColor: argv['nocolor'] || process.env.PRETTYJSON_NOCOLOR,
   noAlign: argv['noalign'] || process.env.PRETTYJSON_NOALIGN,
-  noEscape argv['noescape'] || process.env.PRETTYJSON_NOESCAPE,
+  escape: argv['escape'] || process.env.PRETTYJSON_ESCAPE,
   inlineArrays: argv['inline-arrays'] || process.env.PRETTYJSON_INLINE_ARRAYS
 };
 

--- a/lib/prettyjson.js
+++ b/lib/prettyjson.js
@@ -78,7 +78,7 @@ var indentLines = function(string, spaces){
 var renderToArray = function(data, options, indentation) {
 
   if (typeof data === 'string' && data.match(conflictChars) &&
-      !options.noEscape) {
+      options.escape) {
     data = JSON.stringify(data);
   }
 
@@ -212,7 +212,7 @@ exports.render = function render(data, options, indentation) {
   options.defaultIndentation = options.defaultIndentation || 2;
   options.noColor = !!options.noColor;
   options.noAlign = !!options.noAlign;
-  options.noEscape = !!options.noEscape;
+  options.escape = !!options.escape;
 
   options.stringColor = options.stringColor || null;
 

--- a/lib/prettyjson.js
+++ b/lib/prettyjson.js
@@ -4,6 +4,8 @@
 var colors = require('colors/safe');
 var Utils = require('./utils');
 
+var conflictChars = /[^\w\s\n\r\v\t\.,]/i;
+
 exports.version = require('../package.json').version;
 
 // Helper function to detect if an object can be directly serializable
@@ -74,6 +76,12 @@ var indentLines = function(string, spaces){
 };
 
 var renderToArray = function(data, options, indentation) {
+
+  if (typeof data === 'string' && data.match(conflictChars) &&
+      !options.noEscape) {
+    data = JSON.stringify(data);
+  }
+
   if (isSerializable(data, false, options)) {
     return [Utils.indent(indentation) + addColorToData(data, options)];
   }
@@ -204,6 +212,7 @@ exports.render = function render(data, options, indentation) {
   options.defaultIndentation = options.defaultIndentation || 2;
   options.noColor = !!options.noColor;
   options.noAlign = !!options.noAlign;
+  options.noEscape = !!options.noEscape;
 
   options.stringColor = options.stringColor || null;
 

--- a/test/prettyjson_spec.js
+++ b/test/prettyjson_spec.js
@@ -32,7 +32,9 @@ describe('prettyjson general tests', function() {
 
   it('should output a escaped string if have conflict chars', function () {
     var input = '#irchannel';
-    var output = prettyjson.render(input, {}, 4);
+      var output = prettyjson.render(input, {
+        escape: true,
+      }, 4);
 
     output.should.equal('    "#irchannel"');
   });

--- a/test/prettyjson_spec.js
+++ b/test/prettyjson_spec.js
@@ -30,6 +30,13 @@ describe('prettyjson general tests', function() {
     output.should.equal('    """\n      multiple\n      lines\n    """');
   });
 
+  it('should output a escaped string if have conflict chars', function () {
+    var input = '#irchannel';
+    var output = prettyjson.render(input, {}, 4);
+
+    output.should.equal('    "#irchannel"');
+  });
+
   it('should output an array of strings', function() {
     var input = ['first string', 'second string'];
     var output = prettyjson.render(input);
@@ -282,7 +289,9 @@ describe('Printing numbers, booleans and other objects', function() {
     Error.stackTraceLimit = 1;
     var input = new Error('foo');
     var stack = input.stack.split('\n');
-    var output = prettyjson.render(input, {}, 4);
+    var output = prettyjson.render(input, {
+        noEscape: true,
+    }, 4);
 
     output.should.equal([
       '    ' + colors.green('message: ') + 'foo',


### PR DESCRIPTION
I was an issue generating an YAML for a IRC configuration

```
{ irc:
   { port: 6697,
     secure: true,
     server: 'irc.kernelpanic.com.ar',
     nick: 'somenick',
     channel: '#somechannel' } }
```
It was translated as

```
irc: 
  port:    6697
  secure:  true
  server:  irc.kernelpanic.com.ar
  nick:    somenick
  channel: #somechannel
```
And ```#somechannel``` was taken as a comment. With this merge it's do:

```
irc: 
  port:    6697
  secure:  true
  server:  irc.kernelpanic.com.ar
  nick:    somenick
  channel: "#somechannel"
```

Sorry my pooor english.