### PR TITLE
Update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# prettyjson [![Build Status](https://secure.travis-ci.org/rafeca/prettyjson.png)](http://travis-ci.org/rafeca/prettyjson) [![NPM version](https://badge.fury.io/js/prettyjson.png)](http://badge.fury.io/js/prettyjson) [![Coverage Status](https://coveralls.io/repos/rafeca/prettyjson/badge.png?branch=master)](https://coveralls.io/r/rafeca/prettyjson?branch=master)
+# prettyjson [![Build Status](https://travis-ci.org/rafeca/prettyjson.svg)](https://travis-ci.org/rafeca/prettyjson) [![NPM version](https://badge.fury.io/js/prettyjson.svg)](https://badge.fury.io/js/prettyjson) [![Coverage Status](https://coveralls.io/repos/github/rafeca/prettyjson/badge.svg?branch=master)](https://coveralls.io/github/rafeca/prettyjson?branch=master)
 
 Package for formatting JSON data in a coloured YAML-style, perfect for CLI output.
 


### PR DESCRIPTION
- Use SVG for Travis CI, Version Badge, and Coveralls badges
- Use HTTPS for Travis CI and Version Badge link
- Update Coveralls link as listed on their website