### PR TITLE
add option to color multiline strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It's possible to customize the output through some command line options:
 
 ```bash
 # Change colors
-$ prettyjson --string=red --keys=blue --dash=yellow --number=green package.json
+$ prettyjson --string=red --multiline_string=cyan --keys=blue --dash=yellow --number=green package.json
 
 # Do not use colors
 $ prettyjson --nocolor=1 package.json
@@ -104,7 +104,8 @@ var data = {
 console.log(prettyjson.render(data, {
   keysColor: 'rainbow',
   dashColor: 'magenta',
-  stringColor: 'white'
+  stringColor: 'white',
+  multilineStringColor: 'cyan'
 }));
 ```
 

--- a/bin/prettyjson
+++ b/bin/prettyjson
@@ -10,6 +10,7 @@ var options = {
   dashColor: argv.dash || process.env.PRETTYJSON_DASH,
   defaultIndentation: argv.indent || process.env.PRETTYJSON_INDENT,
   stringColor: argv.string || process.env.PRETTYJSON_STRING,
+  multilineStringColor: argv.multiline_string || process.env.PRETTYJSON_MULTILINE_STRING,
   numberColor: argv.number || process.env.PRETTYJSON_NUMBER,
   noColor: argv['nocolor'] || process.env.PRETTYJSON_NOCOLOR,
   noAlign: argv['noalign'] || process.env.PRETTYJSON_NOALIGN,

--- a/lib/prettyjson.js
+++ b/lib/prettyjson.js
@@ -65,10 +65,18 @@ var addColorToData = function(input, options) {
   return sInput;
 };
 
-var indentLines = function(string, spaces){
+var colorMultilineString = function(options, line) {
+    if (options.multilineStringColor === null || options.noColor) {
+        return line;
+    } else {
+        return colors[options.multilineStringColor](line);
+    }
+};
+
+var indentLines = function(string, spaces, options){
   var lines = string.split('\n');
   lines = lines.map(function(line){
-    return Utils.indent(spaces) + line;
+    return Utils.indent(spaces) + colorMultilineString(options, line);
   });
   return lines.join('\n');
 };
@@ -81,9 +89,9 @@ var renderToArray = function(data, options, indentation) {
   // Unserializable string means it's multiline
   if (typeof data === 'string') {
     return [
-      Utils.indent(indentation) + '"""',
-      indentLines(data, indentation + options.defaultIndentation),
-      Utils.indent(indentation) + '"""'
+      Utils.indent(indentation) + colorMultilineString(options, '"""'),
+      indentLines(data, indentation + options.defaultIndentation, options),
+      Utils.indent(indentation) + colorMultilineString(options, '"""')
     ];
   }
 
@@ -187,11 +195,12 @@ var renderToArray = function(data, options, indentation) {
 // *Example of options hash:*
 //
 //     {
-//       emptyArrayMsg: '(empty)', // Rendered message on empty strings
-//       keysColor: 'blue',        // Color for keys in hashes
-//       dashColor: 'red',         // Color for the dashes in arrays
-//       stringColor: 'grey',      // Color for strings
-//       defaultIndentation: 2     // Indentation on nested objects
+//       emptyArrayMsg: '(empty)',    // Rendered message on empty strings
+//       keysColor: 'blue',           // Color for keys in hashes
+//       dashColor: 'red',            // Color for the dashes in arrays
+//       stringColor: 'grey',         // Color for strings
+//       multilineStringColor: 'cyan' // Color for multiline strings
+//       defaultIndentation: 2        // Indentation on nested objects
 //     }
 exports.render = function render(data, options, indentation) {
   // Default values
@@ -206,6 +215,7 @@ exports.render = function render(data, options, indentation) {
   options.noAlign = !!options.noAlign;
 
   options.stringColor = options.stringColor || null;
+  options.multilineStringColor = options.multilineStringColor || null;
 
   return renderToArray(data, options, indentation).join('\n');
 };

--- a/test/prettyjson_spec.js
+++ b/test/prettyjson_spec.js
@@ -207,6 +207,20 @@ describe('prettyjson general tests', function() {
     ].join('\n'));
   });
 
+  it('should allow to configure colors for multiline strings', function() {
+    var input = 'first line string\nsecond line string';
+    var output = prettyjson.render(
+      input,
+      {multilineStringColor: 'red'}
+    );
+    output.should.equal([
+      colors.red('"""')  ,
+      '  ' + colors.red('first line string'),
+      '  ' + colors.red('second line string'),
+      colors.red('"""')
+    ].join('\n'));
+  });
+
   it('should allow to not use colors', function() {
     var input = {param1: 'first string', param2: ['second string']};
     var output = prettyjson.render(input, {noColor: true});


### PR DESCRIPTION
Hello,

not sure if it's bug or intended but multiline strings weren't colored. This PR fixes it.