### PR TITLE
fix: pin `colors` to `1.4.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prettyjson": "./bin/prettyjson"
   },
   "dependencies": {
-    "colors": "^1.1.2",
+    "colors": "1.4.0",
     "minimist": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
https://snyk.io/blog/open-source-maintainer-pulls-the-plug-on-npm-packages-colors-and-faker-now-what